### PR TITLE
Fix Table in PDF

### DIFF
--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -4,9 +4,7 @@ on:
   release:
     types: [created]
   # FIXME: UNDO THIS CHANGE BEFORE MERGING
-  push:
-    branches:
-      - main
+  pull_request:
 
 env:
   PDF_NAME: access-output-data-specifications-dont-publish-me.pdf

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PDF_NAME: access-output-data-specifications-dont-publish-me.pdf
-  ZENODO_RECORD_ID: 421508
+  ZENODO_RECORD_ID: 496896
 
 jobs:
   add-pdf-to-release-zenodo:

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Update Zenodo Version and Files
         run: |
           python ./scripts/zenodo_update.py \
-            --access-token "${{ secrets.ZENODO_TOKEN }}" \
+            --access-token "${{ secrets.ZENODO_SANDBOX_TOKEN }}" \
             --version "${{ github.event.release.tag_name }}" \
             --id "$ZENODO_RECORD_ID" \
             --files ./site/pdf/$PDF_NAME \

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -3,9 +3,13 @@ name: Add PDF to Release and update Zenodo
 on:
   release:
     types: [created]
+  # FIXME: UNDO THIS CHANGE BEFORE MERGING
+  push:
+    branches:
+      - main
 
 env:
-  PDF_NAME: access-output-data-specifications-${{ github.event.release.tag_name }}.pdf
+  PDF_NAME: access-output-data-specifications-dont-publish-me.pdf
   ZENODO_RECORD_ID: 18167024
 
 jobs:
@@ -27,7 +31,7 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: Set version in mkdocs.yaml
-        run: sed -i -e "s/{release_version}/${{ github.event.release.tag_name }}/g" ./mkdocs.yaml
+        run: sed -i -e "s/{release_version}/XXX/g" ./mkdocs.yaml
 
       - name: make-docs
         run: mkdocs build
@@ -38,8 +42,8 @@ jobs:
       - name: Authenticate GitHub CLI
         run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
         
-      - name: Upload Release Files
-        run: gh release upload ${{ github.event.release.tag_name }} ./site/pdf/$PDF_NAME
+#      - name: Upload Release Files
+#        run: gh release upload ${{ github.event.release.tag_name }} ./site/pdf/$PDF_NAME
 
       - name: Update Zenodo Version and Files
         run: |
@@ -48,6 +52,5 @@ jobs:
             --version "${{ github.event.release.tag_name }}" \
             --id "$ZENODO_RECORD_ID" \
             --files ./site/pdf/$PDF_NAME \
-            --production \
             --draft \
             --verbose

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PDF_NAME: access-output-data-specifications-dont-publish-me.pdf
-  ZENODO_RECORD_ID: 18167024
+  ZENODO_RECORD_ID: 421526
 
 jobs:
   add-pdf-to-release-zenodo:

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   PDF_NAME: access-output-data-specifications-dont-publish-me.pdf
-  ZENODO_RECORD_ID: 421526
+  ZENODO_RECORD_ID: 421508
 
 jobs:
   add-pdf-to-release-zenodo:

--- a/.github/workflows/add_pdf_to_release_and_zenodo.yml
+++ b/.github/workflows/add_pdf_to_release_and_zenodo.yml
@@ -20,11 +20,11 @@ jobs:
         with:
           python-version: 3.12.3
 
-      - name: Install dependancies
-        run: python -m pip install mkdocs mkdocs-with-pdf requests
-
       - name: Checkout source
         uses: actions/checkout@v5
+
+      - name: Install dependancies
+        run: python -m pip install -r requirements.txt
 
       - name: Set version in mkdocs.yaml
         run: sed -i -e "s/{release_version}/${{ github.event.release.tag_name }}/g" ./mkdocs.yaml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,10 +6,10 @@ build:
     python: "3"
   jobs:
     pre_install:
-      - pip install mkdocs-with-pdf
+      - pip install -r requirements.txt
     post_build:
       - mkdir -pv $READTHEDOCS_OUTPUT/pdf/
-      - mv $READTHEDOCS_OUTPUT/html/pdf/document.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf
+      - mv -v $READTHEDOCS_OUTPUT/html/pdf/document.pdf $READTHEDOCS_OUTPUT/pdf/$READTHEDOCS_PROJECT.pdf
 mkdocs:
   configuration: mkdocs.yaml
 

--- a/docs/mapping.md
+++ b/docs/mapping.md
@@ -45,7 +45,7 @@ if a cell is 'unknown' then a mapping has not been defined by ACCESS-MOPPy.
       <td>mass_fraction_of_cloud_ice_in_air</td>
       <td>kg kg-1</td>
       <td>mon</td>
-      <td>fld_s02i309 (gridbox lsc qcf in radiation&nbsp;&nbsp; kg/kg)</td>
+      <td>fld_s02i309 (gridbox lsc qcf in radiation   kg/kg)</td>
       <td>level_to_height(fld_s02i309)</td>
     </tr>
     <tr>
@@ -81,7 +81,7 @@ if a cell is 'unknown' then a mapping has not been defined by ACCESS-MOPPy.
       <td>mass_fraction_of_cloud_liquid_water_in_air</td>
       <td>kg kg-1</td>
       <td>mon</td>
-      <td>fld_s02i308 (gridbox lsc qcl in radiation&nbsp;&nbsp; kg/kg)</td>
+      <td>fld_s02i308 (gridbox lsc qcl in radiation   kg/kg)</td>
       <td>level_to_height(fld_s02i308)</td>
     </tr>
     <tr>
@@ -270,7 +270,7 @@ if a cell is 'unknown' then a mapping has not been defined by ACCESS-MOPPy.
       <td>atmosphere_mass_content_of_water_vapor</td>
       <td>kg m-2</td>
       <td>mon</td>
-      <td>fld_s30i404 (total column wet mass&nbsp;&nbsp;rho grid),<br>fld_s30i403 (total column dry mass&nbsp;&nbsp;rho grid),<br>fld_s30i405 (atmosphere_cloud_liquid_water_content),<br>fld_s30i406 (atmosphere_cloud_ice_content)</td>
+      <td>fld_s30i404 (total column wet mass  rho grid),<br>fld_s30i403 (total column dry mass  rho grid),<br>fld_s30i405 (atmosphere_cloud_liquid_water_content),<br>fld_s30i406 (atmosphere_cloud_ice_content)</td>
       <td>fld_s30i404 - (fld_s30i403 + fld_s30i405 + fld_s30i406)</td>
     </tr>
     <tr>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-json_ref_dict
-pandas
-tabulate
-CMIP7-data-request-api
+json_ref_dict == 0.7.2
+pandas == 2.3.3
+tabulate == 0.9.0
+CMIP7-data-request-api == 1.3
 access-moppy @ git+https://github.com/ACCESS-NRI/ACCESS-MOPPy@49032ad
-mkdocs-with-pdf
+mkdocs-with-pdf ==0.9.3
+requests == 2.32.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 json_ref_dict == 0.7.2
 pandas == 2.3.3
 tabulate == 0.9.0
-CMIP7-data-request-api == 1.3
+CMIP7-data-request-api
 access-moppy @ git+https://github.com/ACCESS-NRI/ACCESS-MOPPy@49032ad
 mkdocs-with-pdf ==0.9.3
 requests == 2.32.5


### PR DESCRIPTION
Attempting to resolve issue with how specification tables are displayed in the pdf artefacts.

Currently local build with mkdocs is acceptable but builds for readthedocs & zenodo are not.

Closes #20 